### PR TITLE
Fixes

### DIFF
--- a/src/sdl2imgshow.c
+++ b/src/sdl2imgshow.c
@@ -184,7 +184,7 @@ int main(int argc, char *argv[])
     const char *option_select_file=NULL;
     const char *default_select=NULL;
 
-    while (!finished && (opt = getopt(argc, argv, "ODqkwWz:i:f:t:c:s:d:o:a:S:p:b:T:F:G:x:X:")) != -1)
+    while (!finished && (opt = getopt(argc, argv, "z:T:F:G:i:a:f:t:c:P:S:s:p:d:o:DqkwWOb:x:X:")) != -1)
     {
         switch (opt)
         {
@@ -364,7 +364,7 @@ int main(int argc, char *argv[])
             SDL_DestroyWindow(window);
 
             sdl_do_quit();
-            return EXIT_FAILURE;            
+            return EXIT_FAILURE;
         }
 
         if (default_select != NULL)
@@ -482,7 +482,7 @@ int main(int argc, char *argv[])
 
             // Render Textures
             while (current != NULL)
-            {   
+            {
                 // fprintf(stderr, "- %p\n", current);
 
                 if (current->imageTexture != NULL)
@@ -1004,7 +1004,7 @@ bool load_font(const char *fontFile)
     else
     {
         scaleSize = (int)(float)((screenHeight / 480.0f) * (float)fontSize);
-    } 
+    }
 
     char *fontRef = sub_vars(fontFile);
 

--- a/src/util.c
+++ b/src/util.c
@@ -317,6 +317,9 @@ int get_image_size(const char *size)
     if (strcasecmp(size, "original") == 0)
         return SIZE_ORIGINAL;
 
+    if (strcasecmp(size, "stretch") == 0)
+        return SIZE_STRETCH;
+
     return SIZE_VERTICAL;
 }
 
@@ -345,21 +348,21 @@ void calculate_texture_size(SDL_Texture *imageTexture, SDL_Rect *textureRect, in
     // Set initial width and height
     int textureWidth = originalWidth;
     int textureHeight = originalHeight;
+    int rectWidth;
+    int rectHeight;
 
     // Calculate new width and height based on size enum
     switch (size)
     {
     case SIZE_FIT:
         // Fit the texture within screen dimensions while considering margins
-        if (originalWidth > screenWidth - globalMargins.x - globalMargins.w)
-        {
-            textureWidth = screenWidth - globalMargins.x - globalMargins.w;
-            textureHeight = (originalHeight * textureWidth) / originalWidth;
-        }
-        if (textureHeight > screenHeight - globalMargins.y - globalMargins.h)
-        {
-            textureHeight = screenHeight - globalMargins.y - globalMargins.h;
-            textureWidth = (originalWidth * textureHeight) / originalHeight;
+        rectWidth = screenWidth - globalMargins.x - globalMargins.w;
+        rectHeight = screenHeight - globalMargins.y - globalMargins.h;
+        textureWidth = rectWidth;
+        textureHeight = textureWidth * originalHeight / originalWidth;
+        if (textureHeight > rectHeight) {
+          textureHeight = rectHeight;
+          textureWidth = textureHeight * originalWidth / originalHeight;
         }
         break;
 


### PR DESCRIPTION
-P flag was missing in getopt, also reordered flags as they appear in the switch.
-S fit didn't fit well ( ignore case where original size where lower than target rect and not fit correctly if it was highter)
-S stretch argument was not parsed